### PR TITLE
fix(table): add border in table for mdx and fix overflow behaviour

### DIFF
--- a/gatsby-theme-mds/src/components/Layout.js
+++ b/gatsby-theme-mds/src/components/Layout.js
@@ -136,7 +136,7 @@ const Layout = ({
 
   const PreviewWithPropTable = ({ name }) => {
     return (
-      <div>
+      <div className="overflow-x-scroll">
         <ArgsTable rows={getPropTableData(name)} />
       </div>
     );

--- a/gatsby-theme-mds/src/components/PropsTable/index.js
+++ b/gatsby-theme-mds/src/components/PropsTable/index.js
@@ -176,7 +176,7 @@ const StoryComp = ({
               </div>
             </CardHeader>
             <CardBody className='d-flex flex-column align-items-center'>
-              <div className='w-100' ref={testRef}>
+              <div className='w-100 overflow-x-scroll' ref={testRef}>
                 <LivePreview
                   className='p-8 mw-100 mh-100 d-block'
                   style={{ zoom: zoom }}

--- a/gatsby-theme-mds/src/css/style.css
+++ b/gatsby-theme-mds/src/css/style.css
@@ -59,7 +59,7 @@
   font-family: "Roboto mono";
 }
 
-.A11y-markdown code{
+.A11y-markdown code {
   background-color: var(--secondary-lightest);
   border: 1px solid var(--secondary-light);
   font-weight: var(--font-weight-bold);
@@ -71,14 +71,27 @@
   font-size: var(--spacing-l);
 }
 
-.A11y-markdown code{
-  background-color: var(--secondary-lightest);
+.overflow-x-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.overflow-x-scroll {
+  overflow-x: scroll;
+  scroll-behavior: smooth;
+}
+
+table {
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+table th,
+table td {
   border: 1px solid var(--secondary-light);
-  font-weight: var(--font-weight-bold);
-  color: var(--inverse);
-  line-height: 1;
-  padding: 3px 5px;
-  white-space: nowrap;
-  border-radius: var(--spacing-m);
-  font-size: var(--spacing-l);
+  padding: var(--spacing-l);
+}
+
+.docblock-argstable th,
+.docblock-argstable td {
+  border: none;
 }


### PR DESCRIPTION
This PR resolves the following issues:
- Border for tables used in markdown files
- fix overflow behaviour of component props table
- Add overflow: scroll for component preview card 